### PR TITLE
Упрощает разметку фида

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import yaml from 'js-yaml';
 import htmlmin from 'html-minifier-terser';
 import markdownIt from 'markdown-it';
+import { stripHeadings, stripLists } from './scripts/strip-tags.js';
 import minifyXml from 'minify-xml';
 
 const markdown = markdownIt({ html: true });
@@ -51,6 +52,12 @@ export default (config) => {
 	});
 
 	config.ignores.add('src/template');
+
+	config.amendLibrary('md', (markdown) => {
+		markdown
+			.use(stripHeadings)
+			.use(stripLists);
+	});
 
 	return {
 		dir: {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import yaml from 'js-yaml';
 import htmlmin from 'html-minifier-terser';
 import markdownIt from 'markdown-it';
-import { stripHeadings, stripLists } from './scripts/strip-tags.js';
+import { stripHeadings } from './scripts/strip-tags.js';
 import minifyXml from 'minify-xml';
 
 const markdown = markdownIt({ html: true });
@@ -54,9 +54,7 @@ export default (config) => {
 	config.ignores.add('src/template');
 
 	config.amendLibrary('md', (markdown) => {
-		markdown
-			.use(stripHeadings)
-			.use(stripLists);
+		markdown.use(stripHeadings);
 	});
 
 	return {

--- a/scripts/strip-tags.js
+++ b/scripts/strip-tags.js
@@ -1,0 +1,41 @@
+function stripHeadings(md) {
+	md.core.ruler.push('strip_headings', (state) => {
+		state.tokens.forEach((token) => {
+			if (token.type === 'heading_open') {
+				token.tag = 'p';
+				token.type = 'paragraph_open';
+			}
+
+			if (token.type === 'heading_close') {
+				token.tag = 'p';
+				token.type = 'paragraph_close';
+			}
+		});
+	});
+}
+
+function stripLists(md) {
+	md.core.ruler.push('strip_lists', (state) => {
+		state.tokens.forEach((token) => {
+			if (token.type === 'bullet_list_open') {
+				token.tag = 'p';
+				token.type = 'paragraph_open';
+			}
+
+			if (token.type === 'bullet_list_close') {
+				token.tag = 'p';
+				token.type = 'paragraph_close';
+			}
+
+			if (token.type === 'list_item_open') {
+				token.hidden = true;
+			}
+
+			if (token.type === 'list_item_close') {
+				token.hidden = true;
+			}
+		});
+	});
+}
+
+export { stripHeadings, stripLists };

--- a/scripts/strip-tags.js
+++ b/scripts/strip-tags.js
@@ -14,28 +14,4 @@ function stripHeadings(md) {
 	});
 }
 
-function stripLists(md) {
-	md.core.ruler.push('strip_lists', (state) => {
-		state.tokens.forEach((token) => {
-			if (token.type === 'bullet_list_open') {
-				token.tag = 'p';
-				token.type = 'paragraph_open';
-			}
-
-			if (token.type === 'bullet_list_close') {
-				token.tag = 'p';
-				token.type = 'paragraph_close';
-			}
-
-			if (token.type === 'list_item_open') {
-				token.hidden = true;
-			}
-
-			if (token.type === 'list_item_close') {
-				token.hidden = true;
-			}
-		});
-	});
-}
-
-export { stripHeadings, stripLists };
+export { stripHeadings };

--- a/src/feed.11ty.js
+++ b/src/feed.11ty.js
@@ -14,15 +14,15 @@ export default {
 						<title>${episode.fileSlug}. ${episode.data.title}</title>
 						<link>${data.meta.url}${episode.fileSlug}/</link>
 						<pubDate>${episode.date.toUTCString()}</pubDate>
-						<description><![CDATA[<h2>Ведущие</h2><p>${
+						<description><![CDATA[<p>Ведущие: ${
 							hosts
 						}</p>${
 							episode.data.chapters ?
-								`<h2>Темы</h2><ul>${
+								`<p>Темы</p><p>${
 									episode.data.chapters
-										.map(chapter => `<li>${chapter.time} ${chapter.title}</li>`)
-										.join('')
-								}</ul>`
+										.map(chapter => `${chapter.time} ${chapter.title}`)
+										.join('<br>')
+								}</p>`
 							: ''
 						}${
 							await this.htmlmin(episode.content)

--- a/src/feed.11ty.js
+++ b/src/feed.11ty.js
@@ -18,11 +18,11 @@ export default {
 							hosts
 						}</p>${
 							episode.data.chapters ?
-								`<p>Темы</p><p>${
+								`<p>Темы</p><ul>${
 									episode.data.chapters
-										.map(chapter => `${chapter.time} ${chapter.title}`)
-										.join('<br>')
-								}</p>`
+										.map(chapter => `<li>${chapter.time} ${chapter.title}</li>`)
+										.join('')
+								}</ul>`
 							: ''
 						}${
 							await this.htmlmin(episode.content)


### PR DESCRIPTION
Вероятно, fix #8

Упрощаю фид, чтобы его лучше парсили платформы, включая Ютуб.

- [x] Заголовок заменяется на параграф
- [ ] Обёртка списка заменяется на параграф
- [ ] Элемент списка заменяется на буллит в начале и `<br>` в конце

До сих пор получилось всё, кроме последнего пункта:

### Было

```html
<ul>
  <li><a href="https://nodejs.org/en/blog/release/v22.11.0">LTS Node.js 22</a></li>
  <li><a href="https://survey.devographics.com/en-US/survey/state-of-react/2024">State of React</a></li>
  <li><a href="https://github.com/CSS-Next/css-next/issues/105#issuecomment-2445341089">New CSS logo?</a></li>
</ul>
```

### Стало

```html
<p>
  <a href="https://nodejs.org/en/blog/release/v22.11.0">LTS Node.js 22</a>
  <a href="https://survey.devographics.com/en-US/survey/state-of-react/2024">State of React</a>
  <a href="https://github.com/CSS-Next/css-next/issues/105#issuecomment-2445341089">New CSS logo?</a>
</p>
```

### Хочется

```html
<p>
  • <a href="https://nodejs.org/en/blog/release/v22.11.0">LTS Node.js 22</a><br>
  • <a href="https://survey.devographics.com/en-US/survey/state-of-react/2024">State of React</a><br>
  • <a href="https://github.com/CSS-Next/css-next/issues/105#issuecomment-2445341089">New CSS logo?</a>
</p>
```

Пробовал что-то вроде:

```js
const br = new state.Token('html_inline', '', 0);
br.content = '<br>';
state.tokens.splice(state.tokens.indexOf(token) + 1, 0, br);
```

Но что-то `markdown-it` не хочет меня понимать.