### PR TITLE
Добавляет правила для преобразования списков в параграфы в markdown

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import yaml from 'js-yaml';
 import htmlmin from 'html-minifier-terser';
 import markdownIt from 'markdown-it';
-import { stripHeadings } from './scripts/strip-tags.js';
+import { stripHeadings, stripLists } from './scripts/strip-tags.js';
 import minifyXml from 'minify-xml';
 
 const markdown = markdownIt({ html: true });
@@ -55,6 +55,7 @@ export default (config) => {
 
 	config.amendLibrary('md', (markdown) => {
 		markdown.use(stripHeadings);
+		markdown.use(stripLists);
 	});
 
 	return {

--- a/scripts/strip-tags.js
+++ b/scripts/strip-tags.js
@@ -14,4 +14,49 @@ function stripHeadings(md) {
 	});
 }
 
-export { stripHeadings };
+function stripLists(md) {
+	md.core.ruler.push('strip_lists', (state) => {
+		let newTokens = [];
+		let isListItemProcessing = false;
+
+		state.tokens.forEach((token) => {
+			if (token.type === 'bullet_list_open') {
+				const listOpenToken = new state.Token('html_paragraph', 'p', 1);
+				newTokens.push(listOpenToken);
+				return;
+			}
+
+			if (token.type === 'bullet_list_close') {
+				const listCloseToken = new state.Token('html_paragraph', 'p', -1);
+				newTokens.push(listCloseToken);
+				return;
+			}
+
+			if (token.type === 'list_item_open') {
+				isListItemProcessing = true;
+				return;
+			}
+
+			if (token.type === 'list_item_close') {
+				isListItemProcessing = false;
+				return;
+			}
+
+			if (token.type === 'inline' && isListItemProcessing) {
+				const bulletToken = new state.Token('html_inline', '', 0);
+				bulletToken.content = '• ';
+				token.children.unshift(bulletToken);
+
+				const breakToken = new state.Token('html_inline', '', 0);
+				breakToken.content = '<br/>';
+				token.children.push(breakToken);
+			}
+
+			newTokens.push(token);
+		});
+
+		state.tokens = newTokens;
+	});
+}
+
+export { stripHeadings, stripLists };

--- a/scripts/strip-tags.js
+++ b/scripts/strip-tags.js
@@ -48,7 +48,7 @@ function stripLists(md) {
 				token.children.unshift(bulletToken);
 
 				const breakToken = new state.Token('html_inline', '', 0);
-				breakToken.content = '<br/>';
+				breakToken.content = '<br>';
 				token.children.push(breakToken);
 			}
 

--- a/src/feed.11ty.js
+++ b/src/feed.11ty.js
@@ -18,11 +18,11 @@ export default {
 							hosts
 						}</p>${
 							episode.data.chapters ?
-								`<p>Темы</p><ul>${
+								`<p>Темы</p><p>${
 									episode.data.chapters
-										.map(chapter => `<li>${chapter.time} ${chapter.title}</li>`)
+										.map(chapter => `${chapter.time} ${chapter.title}<br/>`)
 										.join('')
-								}</ul>`
+								}</p>`
 							: ''
 						}${
 							await this.htmlmin(episode.content)

--- a/src/feed.11ty.js
+++ b/src/feed.11ty.js
@@ -20,7 +20,7 @@ export default {
 							episode.data.chapters ?
 								`<p>Темы</p><p>${
 									episode.data.chapters
-										.map(chapter => `${chapter.time} ${chapter.title}<br/>`)
+										.map(chapter => `${chapter.time} ${chapter.title}<br>`)
 										.join('')
 								}</p>`
 							: ''


### PR DESCRIPTION
Пример того, как можно преобразовывать списки в markdown-it, как описано [здесь](https://github.com/web-standards-ru/podcast/pull/23#issue-2644749292).